### PR TITLE
Publish Agentic AI and Evaluative Regulation insight

### DIFF
--- a/public/insight.html
+++ b/public/insight.html
@@ -166,7 +166,19 @@
 </section>
 
     <!-- INSIGHT PREVIEWS (moved here, inside the main container and before the CTA) -->
-   
+
+<!-- Agentic AI and Evaluative Regulation -->
+<div class="insight-preview">
+  <img src="/img/ai-regulation.png" alt="Agentic AI and Evaluative Regulation">
+  <h3>Agentic AI and evaluative regulation — why optimisation logic may narrow conduct standards</h3>
+  <div class="article-meta">
+    <span class="article-author"><strong>Martyn Hopper</strong></span>
+    <span class="article-date"> &nbsp;•&nbsp; Posted: 25 February 2026</span>
+  </div>
+  <p>As AI systems move from prediction into advice, complaint handling and arrears management, optimisation logic risks quietly redefining what regulatory compliance means in practice. This paper, submitted to the FCA's Mills Review, examines why evaluative conduct standards require governance safeguards that go beyond well-designed objective functions.</p>
+  <a href="/insights/agentic-ai-evaluative-regulation.html" class="read-more">Read more →</a>
+</div>
+
 <!-- Targeted Support -->
 <div class="insight-preview">
   <img src="/img/targeted-support.png" alt="insight">

--- a/public/insights/agentic-ai-evaluative-regulation.html
+++ b/public/insights/agentic-ai-evaluative-regulation.html
@@ -1,0 +1,394 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <!-- Privacy-friendly analytics by Plausible -->
+  <script async src="https://plausible.io/js/pa-7hn1RJH1kbYBi5WmT_E6A.js"></script>
+  <script>window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};plausible.init()</script>
+  <title>Agentic AI and Evaluative Regulation — Optimisation Logic and Conduct Standards | MH&P Insights</title>
+  <meta name="description" content="As AI systems become more agentic, optimisation logic may quietly narrow evaluative conduct standards in retail financial services. A paper submitted to the FCA's Mills Review.">
+  <link rel="canonical" href="https://www.martynhopper.com/insights/agentic-ai-evaluative-regulation.html">
+  <meta property="og:type" content="article">
+  <meta property="og:title" content="Agentic AI and Evaluative Regulation — Optimisation Logic and Conduct Standards | MH&P Insights">
+  <meta property="og:description" content="As AI systems become more agentic, optimisation logic may quietly narrow evaluative conduct standards in retail financial services. A paper submitted to the FCA's Mills Review.">
+  <meta property="og:url" content="https://www.martynhopper.com/insights/agentic-ai-evaluative-regulation.html">
+  <meta property="og:image" content="https://www.martynhopper.com/img/og-image.png">
+  <meta property="og:site_name" content="Martyn Hopper & Partners">
+  <style>
+    body {
+      font-family: 'Segoe UI', sans-serif;
+      background: #111;
+      color: #eee;
+      margin: 0;
+      line-height: 1.7;
+    }
+    .container {
+      width: 90%;
+      max-width: 1000px;
+      margin: auto;
+      padding: 20px;
+    }
+    .site-header {
+      background: #000;
+      color: #fff;
+      padding: 10px 0;
+      text-align: center;
+    }
+    .header-img {
+      width: 100%;
+      height: 320px;
+      display: block;
+      margin-bottom: 10px;
+      object-fit: cover;
+      object-position: center;
+    }
+    .page-title {
+      color: #ccc;
+      text-align: center;
+      margin: 10px 0 30px;
+      font-weight: normal;
+      font-size: 2.2rem;
+    }
+    nav ul {
+      list-style: none;
+      display: flex;
+      justify-content: center;
+      gap: 20px;
+      padding: 0;
+      margin: 0;
+    }
+    nav ul li a {
+      color: #66ccff;
+      text-decoration: none;
+      padding: 8px 16px;
+      border-radius: 4px;
+      transition: all 0.3s ease;
+    }
+    nav ul li a:hover {
+      color: #fff;
+      background: rgba(102, 204, 255, 0.1);
+      transform: translateY(-1px);
+    }
+    nav ul li a.current {
+      color: #fff;
+      background: rgba(102, 204, 255, 0.2);
+    }
+    a {
+      color: #66ccff;
+      transition: color 0.3s ease;
+    }
+    a:hover { color: #fff; }
+    .site-logo {
+      display: block;
+      max-width: 280px;
+      margin: 15px auto;
+    }
+    h1 { font-size: 2.5rem; color: #fff; margin-bottom: 1.5rem; font-weight: 600; }
+    h2 { font-size: 2.2rem; color: #ddd; margin: 2.5rem 0 1.5rem 0; font-weight: 500; }
+    h3 {
+      font-size: 1.6rem;
+      color: #ccc;
+      margin: 2rem 0 1rem 0;
+      font-weight: 500;
+      border-bottom: 2px solid rgba(102, 204, 255, 0.3);
+      padding-bottom: 0.5rem;
+    }
+    p { font-size: 1.1rem; line-height: 1.8; margin-bottom: 1.5rem; color: #eee; }
+    ul { list-style: none; padding: 0; margin: 1.5rem 0; }
+    ul li { margin-bottom: 0.8rem; padding-left: 1rem; position: relative; }
+    ul li::before { content: '▸'; color: #66ccff; font-weight: bold; position: absolute; left: 0; }
+    .byline { color:#aaa; font-size:.95rem; margin:-12px 0 22px; text-align:center; }
+    .byline .author { color:#ddd; }
+    .byline .date { color:#9aa0a6; margin-left:.6rem; }
+
+    @media screen and (max-width: 768px) {
+      .page-title { font-size: 1.8rem; }
+      h2 { font-size: 1.8rem; }
+      h3 { font-size: 1.4rem; }
+      p { font-size: 1.05rem; }
+    }
+
+    .disclaimer-inline {
+      color: #aaa;
+      font-size: 0.8rem;
+      line-height: 1.45;
+      margin: 1.2rem 0 1.6rem;
+      padding-top: 0.6rem;
+      border-top: 1px solid rgba(255,255,255,0.08);
+    }
+    .disclaimer-inline a {
+      color: #bbb;
+      text-decoration: none;
+      border-bottom: 1px dotted rgba(187,187,187,0.3);
+    }
+    .disclaimer-inline a:hover {
+      color: #eee;
+      border-bottom-color: rgba(238,238,238,0.7);
+    }
+
+    footer.site-footer {
+      background: #000;
+      color: #aaa;
+      border-top: 1px solid #222;
+      padding: 20px 0 24px;
+      font-size: 0.72rem;
+      line-height: 1.35;
+      opacity: 0.85;
+    }
+    footer.site-footer:hover { opacity: 1; }
+    footer.site-footer .footer-legal p { margin: 0.3rem 0; }
+    footer.site-footer .legal-links { margin-top: 0.3rem; }
+    footer.site-footer .separator { color: #555; margin: 0 0.5rem; }
+    footer.site-footer a {
+      color: #bbb;
+      text-decoration: none;
+      border-bottom: 1px dotted rgba(187,187,187,0.3);
+    }
+    footer.site-footer a:hover {
+      color: #eee;
+      border-bottom-color: rgba(238,238,238,0.7);
+    }
+    footer.site-footer * { font-size: inherit; }
+    html { -webkit-text-size-adjust: 100%; text-size-adjust: 100%; }
+  </style>
+</head>
+
+<body>
+  <header class="site-header">
+    <div class="container">
+      <img src="/img/logo.png" alt="Martyn Hopper & Partners" class="site-logo"/>
+      <nav>
+        <ul>
+          <li><a href="/index.html">Home</a></li>
+          <li><a href="/about.html">About</a></li>
+          <li><a href="/services.html">Services</a></li>
+          <li><a href="/team.html">Team</a></li>
+          <li><a href="/insight.html" class="current">Insights</a></li>
+          <li><a href="/contact.html">Contact</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <img src="/img/ai-regulation.png" alt="Agentic AI and Evaluative Regulation" class="header-img" />
+  <h2 class="page-title">Agentic AI and Evaluative Regulation</h2>
+
+  <main class="container">
+    <div class="byline">
+      <span class="author"><strong>Martyn Hopper</strong></span>
+      <span class="date">Posted: 25 February 2026</span>
+    </div>
+
+    <article>
+      <p>Artificial intelligence is increasingly embedded across UK retail financial services. Debate around its use has largely focused on bias, explainability, and operational resilience. Those issues matter. But as AI systems become more agentic and autonomous, a different structural question becomes more salient.</p>
+
+      <p>As systems move beyond prediction into customer-facing and judgement-linked functions — advice, targeted support, arrears management, bereavement handling, and complaint resolution — how should regulators and industry ensure that optimisation-driven systems do not narrow evaluative conduct standards in practice, particularly where those standards depend on reason-giving and contestability?</p>
+
+      <p>The risk is not that AI systems fail technically. It is that they succeed in ways that subtly redefine what compliance means.</p>
+
+      <h2>1. Agentic AI and the Shift from Prediction to Decision</h2>
+
+      <p>Traditional models in retail financial services primarily supported discrete functions such as credit scoring or fraud detection.</p>
+
+      <p>Emerging agentic AI systems may (for example):</p>
+      <ul>
+        <li>Interact directly with customers</li>
+        <li>Generate recommendations</li>
+        <li>Determine escalation pathways</li>
+        <li>Draft complaint responses</li>
+        <li>Propose redress outcomes</li>
+        <li>Structure repayment plans</li>
+      </ul>
+
+      <p>These systems do not merely predict; they operationalise regulatory obligations in real time. This creates a qualitatively different governance challenge.</p>
+
+      <p>Machine learning systems:</p>
+      <ul>
+        <li>Are trained on historical data</li>
+        <li>Optimise against measurable objectives</li>
+        <li>Adjust internal parameters to improve predictive performance</li>
+        <li>Produce outputs that maximise defined reward functions</li>
+      </ul>
+
+      <p>Large language models, when embedded into workflows, are no different in principle. They optimise sequence prediction and can be configured to pursue downstream objectives.</p>
+
+      <p>Critically, although they can mimic human reasoning, these systems do not perform such reasoning: they do not reason about legal standards; they do not interpret fairness or good faith; they do not apply reasonableness tests; they do not understand the authority structure of rules vs guidance vs industry practice. They optimise measurable proxies.</p>
+
+      <h2>2. Historical Retail Failures as Stress Tests</h2>
+
+      <p>Past systemic failures — including pensions mis-selling, PPI, discretionary commission arrangements in motor finance, and widespread deficiencies in bereavement and arrears handling — share common characteristics:</p>
+      <ul>
+        <li>Formal compliance processes existed</li>
+        <li>Metrics were monitored</li>
+        <li>Documentation was extensive</li>
+        <li>Incentives operated beneath formal structures</li>
+      </ul>
+
+      <p>In many cases, aggregate indicators (including those established under the FSA/FCA Treating Customers Fairly rules and guidance) did not immediately reveal detriment.</p>
+
+      <p>The failure was not absence of systems, but misalignment between incentives, metrics, and substantive regulatory standards such as suitability, fairness, and good faith.</p>
+
+      <p>As firms adopt agentic AI in advice, customer support, and complaint resolution, the same structural risk arises in a new form: optimisation objectives may become the operative definition of compliance.</p>
+
+      <h2>3. The "Objective Function" Response — and Its Limits</h2>
+
+      <p>It may be argued that this concern is misplaced because firms can define AI objectives to optimise directly for regulatory compliance.</p>
+
+      <p>This response is partly correct. Firms can and should:</p>
+      <ul>
+        <li>Define compliance-aligned objectives</li>
+        <li>Encode constraints</li>
+        <li>Monitor harm indicators</li>
+        <li>Retrain systems where issues emerge</li>
+      </ul>
+
+      <p>However, three structural limits remain in evaluative regulatory domains.</p>
+
+      <h3>3.1 Underspecification of Evaluative Standards</h3>
+
+      <p>Core retail obligations — including acting in good faith, avoiding foreseeable harm, ensuring fair value, and providing suitable advice — are deliberately open-textured.</p>
+
+      <p>They require:</p>
+      <ul>
+        <li>Contextual judgement</li>
+        <li>Balancing competing considerations</li>
+        <li>Interpretation of evolving circumstances</li>
+      </ul>
+
+      <p>No optimisation objective can exhaustively encode these standards. Objective functions necessarily rely on measurable proxies. Metrics are evidence of compliance. They are not equivalent to the standard itself.</p>
+
+      <p>There is ample historic and academic work exploring the limits of measurable proxies and performance metrics and the perverse incentives to which they can give rise. Embedding them in agentic AI risks similar problems at increased scale and velocity and greater opacity.</p>
+
+      <h3>3.2 Reason-Giving and Contestability</h3>
+
+      <p>Retail regulatory legitimacy depends not only on aggregate outcomes but on the ability to justify individual decisions. Under DISP and Financial Ombudsman Service (FOS) review, for example, the question is typically: was the firm's decision fair and reasonable in the circumstances?</p>
+
+      <p>An optimisation system produces outputs calibrated against defined objectives. It does not, by itself, provide normative justification. If a consumer challenging an adverse decision is met with the explanation "the system applied our trained model in line with policy," contestability may become formal rather than substantive.</p>
+
+      <p>Meaningful review requires:</p>
+      <ul>
+        <li>Articulation of the relevant regulatory standard</li>
+        <li>Explanation of how it was applied in context</li>
+        <li>Capacity for principled departure from model output</li>
+      </ul>
+
+      <h3>3.3 Objective Function Design Is Itself Normative</h3>
+
+      <p>Defining the system's objective function involves choices about which harms are counted; how trade-offs are weighted; what level of detriment is tolerable; and how commercial constraints are embedded. These are governance decisions, not purely technical matters.</p>
+
+      <p>The risk is not that objectives cannot be specified. It is that they may narrow evaluative standards in ways that are operationally efficient but hidden in system design and therefore insufficiently visible to boards, supervisors, and consumers.</p>
+
+      <h2>4. Practical Consumer-Facing Risks</h2>
+
+      <p>The structural issues above have concrete implications.</p>
+
+      <h3>4.1 Advice and Targeted Support</h3>
+
+      <p>An AI advice agent may be trained to optimise for:</p>
+      <ul>
+        <li>Long-term portfolio performance</li>
+        <li>Predicted complaint minimisation</li>
+        <li>Retention</li>
+        <li>Risk-adjusted suitability scores</li>
+      </ul>
+
+      <p>However, suitability requires consideration of:</p>
+      <ul>
+        <li>Customer preferences</li>
+        <li>Risk appetite nuance</li>
+        <li>Non-financial objectives</li>
+        <li>Changing life circumstances</li>
+      </ul>
+
+      <p>If optimisation objectives shape recommendation boundaries, suitability may be defined by model parameters rather than by open-textured judgement.</p>
+
+      <h3>4.2 Complaint Handling</h3>
+
+      <p>Agentic systems may:</p>
+      <ul>
+        <li>Draft responses</li>
+        <li>Propose redress</li>
+        <li>Predict escalation risk</li>
+        <li>Optimise early settlement strategies</li>
+      </ul>
+
+      <p>If systems are calibrated to minimise FOS referrals or complaint volumes, there is a risk that:</p>
+      <ul>
+        <li>Redress is calibrated to escalation risk rather than fairness</li>
+        <li>Narrative reasoning defends model outputs rather than engages with substantive standards</li>
+      </ul>
+
+      <p>Complaint rates may fall while contestability and fairness weaken.</p>
+
+      <h3>4.3 Arrears and Vulnerability</h3>
+
+      <p>These areas are particularly sensitive. AI may improve detection of vulnerability signals and consistency of treatment.</p>
+
+      <p>However, if repayment plans or support pathways are optimised within recovery or impairment constraints, marginal cases may be resolved by reference to statistical efficiency rather than contextual good faith or fair treatment.</p>
+
+      <p>Where systems become determinative and human override becomes operationally difficult, the firm may struggle to demonstrate that evaluative standards have genuinely been applied.</p>
+
+      <h2>5. Aggregate Metrics vs Individual Fairness</h2>
+
+      <p>AI systems are typically assessed at portfolio level. Retail consumer protection frequently operates at individual level.</p>
+
+      <p>The FCA may wish to consider whether supervisory expectations should ensure that:</p>
+      <ul>
+        <li>Individual outcomes remain reviewable by reference to regulatory standards, not merely model integrity</li>
+        <li>Human override mechanisms are meaningful rather than formal</li>
+        <li>Proxy metrics (complaint rates, retention, comprehension testing) are treated as indicators, not definitions, of compliance</li>
+      </ul>
+
+      <h2>6. Distinguishing Rule Types</h2>
+
+      <p>The interaction between AI and regulation differs by rule type.</p>
+      <ul>
+        <li>Tolerance-based rules (e.g. capital ratios, impact tolerances in operational resilience) align naturally with optimisation.</li>
+        <li>Managerial governance regimes (e.g. operational resilience mapping, and Consumer Duty requirements on product design and governance) can be strengthened by AI modelling.</li>
+        <li>Evaluative conduct standards (e.g. Consumer Duty rules requiring firms to act in good faith and to avoid foreseeable harm) require additional safeguards because legitimacy depends on reason-giving and contestability.</li>
+      </ul>
+
+      <p>Explicit recognition of this distinction may assist firms and supervisors in calibrating expectations.</p>
+
+      <h2>7. Conclusion</h2>
+
+      <p>AI has significant potential to enhance consistency, efficiency, and early harm detection in retail financial services.</p>
+
+      <p>The long-term risk is not technological failure alone. It is that optimisation logic may, over time, narrow the practical meaning of evaluative regulatory standards if not accompanied by governance structures that preserve reason-giving and contestability.</p>
+
+      <p>Agentic AI does not eliminate the structural dynamics that produced past retail failures. It may intensify them if optimisation objectives quietly redefine compliance in practice.</p>
+
+      <p>By addressing these issues proactively, regulators and industry can support innovation while preserving the normative foundations of retail consumer protection.</p>
+
+      <p><em>This paper was originally submitted to the FCA's Mills Review.</em></p>
+    </article>
+  </main>
+
+  <div class="disclaimer-inline container">
+    <strong>This Insight reflects our independent perspective only and is not legal advice.</strong>
+    <a href="/insight-disclaimer.html">Full disclaimer →</a>
+  </div>
+
+  <footer class="site-footer">
+    <div class="container">
+      <div class="footer-legal">
+        <p>© <span id="year"></span> Martyn Hopper &amp; Partners Limited. Company No. 16750161 (England &amp; Wales).</p>
+        <p>Regulatory status: We provide legal and regulatory advisory services. We are not authorised by the Solicitors Regulation Authority to carry on reserved legal activities.</p>
+        <p>Professional indemnity insurance is maintained; details available on request.</p>
+        <p class="legal-links">
+          <a href="/legal.html">Legal &amp; Regulatory Notice</a>
+          <span class="separator">·</span>
+          <a href="/privacy.html">Privacy Notice</a>
+          <span class="separator">·</span>
+          <a href="/insight-disclaimer.html">Insight Disclaimer</a>
+        </p>
+      </div>
+    </div>
+  </footer>
+
+  <script>
+    (function(){var y=document.getElementById('year'); if(y){ y.textContent=new Date().getFullYear(); }})();
+  </script>
+</body>
+</html>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -26,7 +26,7 @@
   </url>
   <url>
     <loc>https://www.martynhopper.com/insight.html</loc>
-    <lastmod>2026-02-12</lastmod>
+    <lastmod>2026-02-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
@@ -53,6 +53,12 @@
     <lastmod>2026-02-12</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.2</priority>
+  </url>
+  <url>
+    <loc>https://www.martynhopper.com/insights/agentic-ai-evaluative-regulation.html</loc>
+    <lastmod>2026-02-25</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.9</priority>
   </url>
   <url>
     <loc>https://www.martynhopper.com/insights/targeted-support.html</loc>


### PR DESCRIPTION
Add new insight page examining how optimisation logic in agentic AI systems may narrow evaluative conduct standards in retail financial services. Originally submitted to the FCA's Mills Review.

- New page: /insights/agentic-ai-evaluative-regulation.html
- Preview card added at top of /insight.html
- Sitemap updated with new entry (2026-02-25)

https://claude.ai/code/session_019DBvnieCjsiPqKjMnGQNTV