### PR TITLE
Add "Meeting the Sellers" insight article

### DIFF
--- a/public/insight.html
+++ b/public/insight.html
@@ -62,6 +62,18 @@
 
     <!-- INSIGHT PREVIEWS (moved here, inside the main container and before the CTA) -->
 
+    <!-- Meeting the Sellers -->
+<div class="insight-preview">
+  <img src="/img/meet-sellers.PNG" alt="The Government is meeting the sellers — the problem is the buyers">
+  <h3>The Government is meeting the sellers. The problem is the buyers.</h3>
+  <div class="article-meta">
+    <span class="article-author"><strong>Martyn Hopper</strong></span>
+    <span class="article-date"> &nbsp;•&nbsp; Posted: 21 July 2026</span>
+  </div>
+  <p>Downing Street has been calling in private equity firms to ask why they are not listing their portfolio companies in London. With takeover bids for UK-listed companies outstripping new listings by 27 to 1, the concern is understandable — but the listings drought has persisted despite years of supply-side reform. The part policy has neglected is demand: the domestic institutions that once anchored UK issuance have been steadily pushed out of it, not by capital markets regulation but by pensions and retail distribution regulation.</p>
+  <a href="/insights/meeting-the-sellers.html" class="read-more">Read more →</a>
+</div>
+
     <!-- The AI Boom and Hidden Debt -->
 <div class="insight-preview">
   <img src="/img/data-centre.png" alt="The AI boom and hidden debt">

--- a/public/insights/meeting-the-sellers.html
+++ b/public/insights/meeting-the-sellers.html
@@ -1,0 +1,148 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <!-- Privacy-friendly analytics by Plausible -->
+  <script async src="https://plausible.io/js/pa-7hn1RJH1kbYBi5WmT_E6A.js"></script>
+  <script>window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};plausible.init()</script>
+  <title>The Government is Meeting the Sellers. The Problem is the Buyers. | MH&P Insights</title>
+  <meta name="description" content="Downing Street is asking private equity why they will not list in London. The listings drought is a demand-side problem: the domestic institutions that once anchored UK issuance have been regulated out of the market.">
+  <link rel="canonical" href="https://www.martynhopper.com/insights/meeting-the-sellers.html">
+  <meta property="og:type" content="article">
+  <meta property="og:title" content="The Government is Meeting the Sellers. The Problem is the Buyers. | MH&P Insights">
+  <meta property="og:description" content="Downing Street is asking private equity why they will not list in London. The listings drought is a demand-side problem: the domestic institutions that once anchored UK issuance have been regulated out of the market.">
+  <meta property="og:url" content="https://www.martynhopper.com/insights/meeting-the-sellers.html">
+  <meta property="og:image" content="https://www.martynhopper.com/img/meet-sellers.PNG">
+  <meta property="og:site_name" content="Martyn Hopper & Partners">
+  <link rel="stylesheet" href="/css/style.css">
+</head>
+
+<body>
+  <header class="site-header">
+    <div class="container">
+      <img src="/img/logo.png" alt="Martyn Hopper & Partners" class="site-logo"/>
+      <nav>
+        <ul>
+          <li><a href="/index.html">Home</a></li>
+          <li><a href="/about.html">About</a></li>
+          <li><a href="/services.html">Services</a></li>
+          <li><a href="/team.html">Team</a></li>
+          <li><a href="/insight.html" class="current">Insights</a></li>
+          <li><a href="/contact.html">Contact</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <img src="/img/meet-sellers.PNG" alt="The Government is meeting the sellers — the problem is the buyers" class="header-img" />
+  <h2 class="page-title">The Government is Meeting the Sellers. The Problem is the Buyers.</h2>
+
+  <main class="container">
+    <div class="byline">
+      <span class="author"><strong>Martyn Hopper</strong></span>
+      <span class="date">Posted: 21 July 2026</span>
+    </div>
+
+    <article>
+      <p class="lede">Downing Street has been calling in private equity firms, among them Hg, CD&amp;R, General Atlantic, CVC, EQT and Elliott, to ask why they are not listing their portfolio companies in London (<a href="https://www.ft.com/content/c87970fb-9308-4425-ab4a-8919b0726eab?shareType=nongift" rel="noopener">FT, last week</a>). With seven IPOs this year and takeover bids for UK-listed companies outstripping new listings by 27 to 1, the concern is understandable and the engagement welcome.</p>
+
+      <p>That the listings drought has persisted despite a series of supply-side reforms — a stamp duty holiday for new listings, more flexible director share options, lower free-float requirements, the 2024 overhaul of the listing rules, dual-class shares, prospectus reform — suggests the listing regime was never the whole story. Plenty else pushes companies towards New York: higher US valuations, deeper sector comparables, a larger pool of risk-tolerant growth capital, and a decade of UK economic underperformance. But those are hard to legislate for, and they distract from the part policy has neglected: demand. A sponsor deciding where to float is not only comparing rulebooks; it is comparing the depth of buyers. And the deepest natural buyers of UK equities — the domestic institutions that once anchored new issues and set prices in the mid-cap market — have been steadily pushed out of it, not by capital markets regulation but by pensions and retail distribution regulation. What follows is a story about ownership of new issuance and price discovery, which is what a listings market runs on, rather than about who happens to hold Shell or HSBC in the secondary market.</p>
+
+      <h3>How the buyers were regulated away</h3>
+
+      <p>That has happened in three ways.</p>
+
+      <p>First, defined benefit pensions. In the early 1990s UK pension funds held roughly half their assets in UK equities and were the bedrock of the domestic market. The framework built after Maxwell, and after members lost their pensions when sponsors failed, had a legitimate objective — the security of promised benefits — and it achieved it. But once pension deficits appeared on company balance sheets, prudence came to mean matching liabilities with gilts, not seeking returns. Schemes closed, memberships aged, and the UK equity share of DB assets fell from around a third in 2006 to below 2 per cent by 2023. Some of that shift was the right answer to the wrong question: a mature scheme with pensioners to pay is not the natural provider of permanent risk capital, and de-risking suited its liabilities. But the policy choices that accelerated closure and crystallised short-term deficits turned a gradual adjustment into a rout, and treated the systemic consequence — the loss of the market's largest patient investor — as nobody's concern.</p>
+
+      <p>Second, defined contribution. The charge cap, and a value-for-money culture that in practice measures cost rather than net returns, has driven DC savings into the cheapest available product: global market-cap trackers. The UK is around 3 to 4 per cent of global indices, so roughly 96p of every pound invested in a global tracker is allocated to non-UK-listed companies, most of it US mega-caps. The problem is less passive investment in itself than what a market dominated by it lacks: price-setting, research-intensive, discretionary domestic capital, of the kind that cornerstones a flotation and sustains a mid-cap valuation. That is the capital a listing venue depends on, while the regulatory and commercial default has moved steadily towards low-cost, globally diversified, benchmark-driven investment.</p>
+
+      <p>Third, retail. Cost disclosure rules made investment trusts, historically the UK's principal vehicle for patient retail capital, appear artificially expensive, driving discounts and wind-ups. A risk-warning culture grew up that treats equity ownership primarily as a hazard to be disclaimed. Hundreds of billions now sit in cash ISAs while the same savers' pension money tracks the S&amp;P 500.</p>
+
+      <h3>The demographic objection</h3>
+
+      <p>Is this really just demography — an ageing population and maturing schemes naturally shifting out of equities? Only partly. The closures that aged the DB universe were themselves driven by tax and regulatory change, and demography cannot explain why auto-enrolment savers in their twenties, with forty-year horizons, sit in default funds that hold barely more UK equity than a maturing scheme does. Sweden, Australia and Canada are ageing on similar trajectories, and their savers hold far more domestic equity than ours. Sweden combines a deep domestic equity culture with ISK accounts that make share ownership simple and tax-efficient, and a policy culture that treats it as ordinary rather than dangerous.</p>
+
+      <h3>What is already in train</h3>
+
+      <p>Some of this is, in fairness, at last being addressed. The Pension Schemes Act 2026 rebuilds value for money around net investment performance, costs and service quality, rather than headline charges alone, and drives consolidation into fewer, larger defaults with the scale to invest beyond trackers — the Government's own rationale, that competition on charges pushes schemes away from productive assets, is the argument of this piece. But the first assessments will not arrive until 2028 and the scale requirements not until 2030, and a design risk sits with the FCA and DWP as they write the metrics: if poor benchmark-relative returns can cost a provider its business, providers will hug the benchmark, as Australia's performance test showed. Investment trust cost disclosure is similarly unfinished: the rules that double-counted costs already reflected in trusts' share prices were disapplied in 2024 — first by FCA forbearance, then by legislation excluding closed-ended funds — but only as an interim measure until the new disclosure regime, still being phased in, settles the permanent treatment.</p>
+
+      <p>Stamp duty is half-addressed. A 0.5 per cent levy on purchases of most UK shares creates a persistent marginal incentive to allocate elsewhere, and a holiday for new listings treats the tax as the problem while retaining it. The Treasury's internal argument over £4.3bn of revenue looks different now that AstraZeneca, while keeping its London listing, has begun trading its shares directly in New York: its US trades now escape the tax entirely, at a cost of some £200m a year, and the LSE has identified twenty more companies with the same depositary receipt structures that could follow. The tax base can walk without a single company leaving.</p>
+
+      <h3>The first gap: consumer protection, and the culture it fosters</h3>
+
+      <p>The same regulatory preference for visible cost and benchmark conformity that shaped consumer products has also worn away the discretionary domestic investment capacity a listings market depends on. Start with the Consumer Duty. The FCA now says many of the right things: targeted support, rebalanced risk warnings, its own acknowledgement that millions of consumers are missing out on better returns. The formal rules do recognise that excessive caution can be a harm. The difficulty is that accountability is asymmetric. A loss following a recommendation is visible, attributable to an identifiable firm, and potentially compensable; a loss from twenty years left in cash is diffuse, counterfactual, and attributed to no regulated decision at all. Ombudsman redress requires a breach and a counterfactual, which caution rarely supplies. So even where the rules acknowledge the risk of not investing, the rational institutional bias runs towards caution — and that is what keeps household savings out of the market altogether.</p>
+
+      <p>The assessment machinery that sits alongside the Duty compounds the problem. The fair value regime, and the annual assessments of value fund managers must run, anchor on price in practice: the FCA's own reviews found firms leaning on comparable market rates to justify fees — producing what the regulator itself called price clustering — and its most prominent supervisory interventions since the Duty came into force have repeatedly concerned charges, margins and comparisons with similar products. Performance is assessed too, but against comparator benchmarks. None of these regimes formally defines risk as tracking error. But taken together — cost competition, comparator-based performance scrutiny, and governance that punishes visible underperformance — they create a powerful incentive to stay close to the prevailing benchmark, and that benchmark, global and market-cap-weighted, is the one input the process rarely questions. Consider what that means if US equities, now some two-thirds of the global index and concentrated in a handful of technology stocks, prove to be seriously overvalued. A manager positioned for that could underperform for a decade before being vindicated — as the value managers who refused dot-com valuations were, right up until the crash. The point is not that assessments should reward contrarians: many are simply wrong, there is no reliable way to tell insight from persistent underperformance in advance, and benchmark discipline protects savers from storytelling and style drift. The point is narrower. An assessment framework should be able to distinguish divergence that follows a clearly stated, consistently applied investment philosophy from unexplained underperformance, excessive fees or style drift — and it should not treat the prevailing market-cap benchmark as though it were neutral. It is not: it is itself a concentrated allocation — currently a bet on a handful of US technology companies whose valuations assume an AI transformation of productivity that has yet to arrive. The objection does not depend on predicting an imminent correction. It is that a framework which cannot recognise concentration or valuation risk will keep producing cheap, benchmark-hugging products, and cannot see the risk that matters most to a long-term saver: paying too much for what everyone else owns.</p>
+
+      <h3>The second gap: what £70bn of pension tax relief buys</h3>
+
+      <p>Should the state direct where pension capital goes? Parliament has just given an unsatisfactory answer: the Pension Schemes Act 2026 contains a mandation power so diluted by the fight over it — capped, usable once, not before 2028, sunsetted, with an opt-out where trustees conclude compliance would not be in members' interests — that it functions mainly as a threat everyone insists will never be carried out. That was the predictable end-point of trying to override the fiduciary duties of those managing pension scheme assets.</p>
+
+      <p>A more coherent lever has long been advocated by Baroness Altmann, the former pensions minister. Pension tax relief is estimated to cost the Exchequer around £70bn a year in income tax and NICs foregone. Not all of that is a subsidy in the strict sense — relieving contributions and taxing withdrawals is in part deferral rather than a gift, though the employer NICs relief and the tax-free lump sum are harder to characterise that way. But whatever the precise net figure, it is a very large tax preference granted for a public purpose, and it currently carries no condition requiring any part of the capital to be invested domestically; the last tax preference tied to UK equities disappeared in 1997, almost exactly when the great de-equitisation began. Conditioning a portion of the relief on a minimum domestic allocation would not alter the content of trustees' fiduciary duty, but it would change the economic environment in which they exercise it.</p>
+
+      <p>The standard objection is that this is politically untouchable. The record suggests otherwise. A Conservative chancellor announced a UK-conditioned tax incentive — the British ISA — at a Budget in 2024. His successor scrapped it, but not on principle: the near-universal industry judgement was that a £5,000 add-on allowance was too small to move markets and not worth the complexity it added to an already cluttered ISA landscape — a verdict on the size of the instrument, not on the idea of conditioning. She then pursued the same objective by blunter means, cutting the cash ISA allowance with the explicit aim of redirecting household savings into equities, and took heavy industry fire for it. If anything, the British ISA's fate points towards conditioning where the money is, rather than at the margins of the retail market. These are adjacent precedents rather than proof the principle is settled — but the direction of travel is already conditional: the Act's reserve power hangs over the default funds of every scheme authorised for auto-enrolment, the Government has indicated that the route to the new scale approvals will take account of schemes' investment in UK and productive assets, and regulators will monitor asset allocations annually from 2028. The state is already attaching domestic-investment strings to a state-conferred privilege. It has simply chosen to attach them at the authorisation gateway, where the bargain is invisible, rather than to the relief, where it would be explicit.</p>
+
+      <p>And notice where those strings point. The Mansion House Accord targets, the qualifying assets under the reserve power and the scale-test criteria are all defined around productive finance: private equity, private credit, venture capital, infrastructure, unlisted securities. Listed UK equities count for nothing in any of it. That is not because anyone believed the listed market did not matter to growth; it follows from a narrow accounting logic in which buying shares in the secondary market merely transfers ownership between investors, so only primary capital registers as productive investment. But the logic fails on its own terms. Private capital is invested on the strength of the exit: every growth company is underwritten by reference to where, and at what valuation, it can eventually be floated or sold, and an IPO cannot be priced without aftermarket demand. If London cannot provide the exit, the companies this taxpayer-privileged capital funds will float in New York or be bought by owners who take them there — the taxpayer funds the growth phase at home, and the flotation, the valuation and the mature listed business accrue abroad. The logic also ignores that the listed market is itself an industry: the brokers, analysts, market-makers and advisers built around it generate employment, exports and tax receipts, and have contracted as the market has. A demand-side policy confined to private assets funds the front end of a pipeline whose back end now empties into New York.</p>
+
+      <p>Conditioning tax relief, with listed UK equities among the eligible assets, is the version of the bargain that would put buyers at the London end of that pipeline. There are challenges — defining UK investment when FTSE 100 revenues are largely earned abroad, home-bias risk, a precedent for political interference with retirement savings — and they deserve serious design work rather than dismissal. If the relief foregone were large enough, the condition would bite like compulsion; the honest difference from mandation is not that trustees stay unconstrained, but that the bargain is explicit, priced and visible, rather than buried in an authorisation gateway. It is a more honest conversation than an unusable mandation power, and it asks the right question: not whether the state may direct private capital, but what the public should expect in return for one of the largest tax reliefs it grants.</p>
+
+      <h3>But why should savers pay for the City?</h3>
+
+      <p>London has struggled, a sceptic will say, because its companies and its economy have underperformed, not because anyone stopped investors buying them; global diversification has protected British pensioners from precisely that underperformance; and conditioning relief would force or bribe trustees into more expensive, less diversified domestic assets to prop up the City, hand a windfall to existing shareholders, and dress industrial policy up as pension reform. It deserves a direct answer, and the answer is not that UK assets will outperform — nobody can promise that. It is that a market is an institution, not a naturally occurring phenomenon. Every developed system's capital market was built by domestic savers, currencies, tax rules and liabilities, and a globally market-cap-weighted default is not neutrality but a concentrated allocation choice of its own. Domestic institutions supply the foundational bid — the price discovery, the analyst coverage, the liquidity — that makes a market worth listing on; global capital, mobile and price-sensitive, arrives where that foundation already exists rather than building it. So domestic anchoring is not protectionism; it is the precondition for an open market that international investors will then join. A modest, independently designed domestic allocation, phased in gradually and defined broadly enough to avoid creating captive buyers for incumbent companies, could help deepen the market. It might also reduce exposure to an increasingly concentrated global index, although whether it improved risk-adjusted outcomes would remain an empirical question. But a country that removes its own foundational investor base should not be surprised when its capital market atrophies.</p>
+
+      <h3>A composite failure</h3>
+
+      <p>None of this is to suggest the past thirty years of reform pursued the wrong objectives. Member security, low costs and honest disclosure are all worth having, and each regime delivered on its own terms. The failure is composite: separate frameworks, each optimising a single objective, whose combined effect on the nation's capital was owned by no one. And it is being re-enacted in real time: a listings workstream with no lever over demand, and a pensions workstream whose demand lever points away from the listed market. London's position as a corporate finance centre is falling through the gap between them. If the Government wants to understand why London struggles, it might spend less time asking sellers why they will not sell here, and rather more on the rules that stopped people buying.</p>
+
+      <div class="divider">* * *</div>
+
+      <p><em>Martyn Hopper is the founder of Martyn Hopper &amp; Partners Ltd, a financial services regulatory advisory firm. He previously was a senior regulatory partner at Linklaters and Herbert Smith Freehills and a Head of Enforcement at the Financial Services Authority.</em></p>
+    </article>
+  </main>
+
+  <div class="disclaimer-inline container">
+    <strong>This Insight reflects our independent perspective only and is not legal advice.</strong>
+    <a href="/insight-disclaimer.html">Full disclaimer →</a>
+  </div>
+
+  <!-- FOOTER -->
+  <footer class="site-footer">
+    <div class="container">
+      <div class="footer-inner">
+
+        <div class="footer-legal">
+          <p>© <span id="year"></span> Martyn Hopper &amp; Partners Limited. Company No. 16750161 (England &amp; Wales).</p>
+          <p>We provide legal and regulatory advisory services. We are authorised and regulated by the Solicitors Regulation Authority (“SRA”), with SRA number 8013667.</p>
+          <p>Professional indemnity insurance is maintained; details available on request.</p>
+          <p class="legal-links">
+            <a href="/legal.html">Legal &amp; Regulatory Notice</a>
+            <span class="separator">·</span>
+            <a href="/privacy.html">Privacy Notice</a>
+            <span class="separator">·</span>
+            <a href="/insight-disclaimer.html">Insight Disclaimer</a>
+          </p>
+        </div>
+
+        <div class="footer-badge">
+          <!-- Start of SRA Digital Badge code -->
+          <div style="max-width:200px;max-height:118px;">
+            <div style="position: relative;padding-bottom: 59.1%;height: auto;overflow: hidden;">
+              <iframe frameborder="0" scrolling="no" allowTransparency="true"
+                src="https://cdn.yoshki.com/iframe/55849r.html"
+                style="border:0px; margin:0px; padding:0px; backgroundColor:transparent; top:0px; left:0px; width:100%; height:100%; position: absolute;">
+              </iframe>
+            </div>
+          </div>
+          <!-- End of SRA Digital Badge code -->
+        </div>
+
+      </div>
+
+      <script>
+        (function(){var y=document.getElementById('year'); if(y){ y.textContent=new Date().getFullYear(); }})();
+      </script>
+    </div>
+  </footer>
+</body>
+</html>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -26,7 +26,7 @@
   </url>
   <url>
     <loc>https://www.martynhopper.com/insight.html</loc>
-    <lastmod>2026-06-03</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
@@ -53,6 +53,12 @@
     <lastmod>2026-02-12</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.2</priority>
+  </url>
+  <url>
+    <loc>https://www.martynhopper.com/insights/meeting-the-sellers.html</loc>
+    <lastmod>2026-07-21</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.9</priority>
   </url>
   <url>
     <loc>https://www.martynhopper.com/insights/ai-boom-hidden-debt.html</loc>


### PR DESCRIPTION
## Summary
- Adds new insight article `public/insights/meeting-the-sellers.html` — on the UK listings drought and why the missing piece is demand, not the listing regime — using the existing insight template, Georgia body via `/css/style.css`, byline dated 21 July 2026, and the FT hyperlink from the source doc preserved.
- Adds a preview card at the top of `public/insight.html` using the existing `/img/meet-sellers.PNG` image.
- Adds a `sitemap.xml` entry for the new article and bumps the `insight.html` lastmod.

## Test plan
- [ ] Open `/insights/meeting-the-sellers.html` locally and confirm header image, title, byline, section subheadings, disclaimer, and footer render like other recent insights.
- [ ] Open `/insight.html` and confirm the new preview appears at the top with the correct image, headline, date, and "Read more" link.
- [ ] Click the FT link in the article body and confirm it opens the correct source.
- [ ] Validate `sitemap.xml` still parses.


---
_Generated by [Claude Code](https://claude.ai/code/session_011ckQicrVdmmLCuJVDx5noL)_