### PR TITLE
Point home page "Latest" link at Meeting the Sellers

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -91,7 +91,7 @@
 
   <p>We are typically engaged when regulatory issues become serious — during investigations, supervisory escalation or internal disagreement about risk. We do not replace external counsel or consulting firms. We work alongside them, advising boards and senior executives directly on the decisions for which they are accountable.</p>
 
-  <p class="featured-insight"><em>Latest: <a href="/insights/ai-boom-hidden-debt.html">"The AI Boom Is Built on More Debt Than It Seems — and No One Can Yet See How Much"</a> — 3 June 2026</em></p>
+  <p class="featured-insight"><em>Latest: <a href="/insights/meeting-the-sellers.html">"The Government is Meeting the Sellers. The Problem is the Buyers."</a> — 21 July 2026</em></p>
 
   <div class="cta-buttons">
     <a href="/contact.html" class="cta-button">Start a conversation</a>


### PR DESCRIPTION
## Summary
- Updates the "Latest" featured-insight line on `public/index.html` to point at `/insights/meeting-the-sellers.html` (21 July 2026) instead of the previous AI-boom article.

Follow-up to #8, which added the article itself but did not update the home page link.

## Test plan
- [ ] After deploy, load the home page and confirm the "Latest" italic line reads "The Government is Meeting the Sellers. The Problem is the Buyers." with the 21 July 2026 date and that the link opens the new article.


---
_Generated by [Claude Code](https://claude.ai/code/session_011ckQicrVdmmLCuJVDx5noL)_